### PR TITLE
feat(preview2-shim): add iwa direct-socket implementation

### DIFF
--- a/packages/preview2-shim/lib/iwa/cli.js
+++ b/packages/preview2-shim/lib/iwa/cli.js
@@ -1,0 +1,159 @@
+import { _setCwd as fsSetCwd } from './filesystem.js';
+import { streams } from './io.js';
+const { InputStream, OutputStream } = streams;
+
+const symbolDispose = Symbol.dispose ?? Symbol.for('dispose');
+
+let _env = [],
+    _args = [],
+    _cwd = '/';
+export function _setEnv(envObj) {
+    _env = Object.entries(envObj);
+}
+export function _setArgs(args) {
+    _args = args;
+}
+
+export function _setCwd(cwd) {
+    fsSetCwd((_cwd = cwd));
+}
+
+export const environment = {
+    getEnvironment() {
+        return _env;
+    },
+    getArguments() {
+        return _args;
+    },
+    initialCwd() {
+        return _cwd;
+    },
+};
+
+class ComponentExit extends Error {
+    constructor(code) {
+        super(`Component exited ${code === 0 ? 'successfully' : 'with error'}`);
+        this.exitError = true;
+        this.code = code;
+    }
+}
+
+export const exit = {
+    exit(status) {
+        throw new ComponentExit(status.tag === 'err' ? 1 : 0);
+    },
+    exitWithCode(code) {
+        throw new ComponentExit(code);
+    },
+};
+
+/**
+ * @param {import('../common/io.js').InputStreamHandler} handler
+ */
+export function _setStdin(handler) {
+    stdinStream.handler = handler;
+}
+/**
+ * @param {import('../common/io.js').OutputStreamHandler} handler
+ */
+export function _setStderr(handler) {
+    stderrStream.handler = handler;
+}
+/**
+ * @param {import('../common/io.js').OutputStreamHandler} handler
+ */
+export function _setStdout(handler) {
+    stdoutStream.handler = handler;
+}
+
+const stdinStream = new InputStream({
+    blockingRead(_len) {
+        // TODO
+    },
+    subscribe() {
+        // TODO
+    },
+    [symbolDispose]() {
+        // TODO
+    },
+});
+let textDecoder = new TextDecoder();
+const stdoutStream = new OutputStream({
+    write(contents) {
+        if (contents[contents.length - 1] == 10) {
+            // console.log already appends a new line
+            contents = contents.subarray(0, contents.length - 1);
+        }
+        console.log(textDecoder.decode(contents));
+    },
+    blockingFlush() {},
+    [symbolDispose]() {},
+});
+const stderrStream = new OutputStream({
+    write(contents) {
+        if (contents[contents.length - 1] == 10) {
+            // console.error already appends a new line
+            contents = contents.subarray(0, contents.length - 1);
+        }
+        console.error(textDecoder.decode(contents));
+    },
+    blockingFlush() {},
+    [symbolDispose]() {},
+});
+
+export const stdin = {
+    InputStream,
+    getStdin() {
+        return stdinStream;
+    },
+};
+
+export const stdout = {
+    OutputStream,
+    getStdout() {
+        return stdoutStream;
+    },
+};
+
+export const stderr = {
+    OutputStream,
+    getStderr() {
+        return stderrStream;
+    },
+};
+
+class TerminalInput {}
+class TerminalOutput {}
+
+const terminalStdoutInstance = new TerminalOutput();
+const terminalStderrInstance = new TerminalOutput();
+const terminalStdinInstance = new TerminalInput();
+
+export const terminalInput = {
+    TerminalInput,
+};
+
+export const terminalOutput = {
+    TerminalOutput,
+};
+
+export const terminalStderr = {
+    TerminalOutput,
+    getTerminalStderr() {
+        return terminalStderrInstance;
+    },
+};
+
+export const terminalStdin = {
+    TerminalInput,
+    getTerminalStdin() {
+        return terminalStdinInstance;
+    },
+};
+
+export const terminalStdout = {
+    TerminalOutput,
+    getTerminalStdout() {
+        return terminalStdoutInstance;
+    },
+};

--- a/packages/preview2-shim/lib/iwa/clocks.js
+++ b/packages/preview2-shim/lib/iwa/clocks.js
@@ -1,0 +1,35 @@
+export const monotonicClock = {
+    resolution() {
+        // usually we dont get sub-millisecond accuracy in the browser
+        // Note: is there a better way to determine this?
+        return 1e6;
+    },
+    now() {
+        // performance.now() is in milliseconds, but we want nanoseconds
+        return BigInt(Math.floor(performance.now() * 1e6));
+    },
+    subscribeInstant(instant) {
+        instant = BigInt(instant);
+        const now = this.now();
+        if (instant <= now) {
+            return this.subscribeDuration(0);
+        }
+        return this.subscribeDuration(instant - now);
+    },
+    subscribeDuration(_duration) {
+        _duration = BigInt(_duration);
+        console.log(`[monotonic-clock] subscribe`);
+    },
+};
+
+export const wallClock = {
+    now() {
+        let now = Date.now(); // in milliseconds
+        const seconds = BigInt(Math.floor(now / 1e3));
+        const nanoseconds = (now % 1e3) * 1e6;
+        return { seconds, nanoseconds };
+    },
+    resolution() {
+        return { seconds: 0n, nanoseconds: 1e6 };
+    },
+};

--- a/packages/preview2-shim/lib/iwa/filesystem.js
+++ b/packages/preview2-shim/lib/iwa/filesystem.js
@@ -1,0 +1,333 @@
+import { streams } from './io.js';
+import { environment } from './cli.js';
+
+const { InputStream, OutputStream } = streams;
+
+let _cwd = '/';
+
+export function _setCwd(cwd) {
+    _cwd = cwd;
+}
+
+export function _setFileData(fileData) {
+    _fileData = fileData;
+    _rootPreopen[0] = new Descriptor(fileData);
+    const cwd = environment.initialCwd();
+    _setCwd(cwd || '/');
+}
+
+export function _getFileData() {
+    return JSON.stringify(_fileData);
+}
+
+let _fileData = { dir: {} };
+
+const timeZero = {
+    seconds: BigInt(0),
+    nanoseconds: 0,
+};
+
+function getChildEntry(parentEntry, subpath, openFlags) {
+    if (
+        subpath === '.' &&
+        _rootPreopen &&
+        descriptorGetEntry(_rootPreopen[0]) === parentEntry
+    ) {
+        subpath = _cwd;
+        if (subpath.startsWith('/') && subpath !== '/') {
+            subpath = subpath.slice(1);
+        }
+    }
+    let entry = parentEntry;
+    let segmentIdx;
+    do {
+        if (!entry || !entry.dir) {
+            throw 'not-directory';
+        }
+        segmentIdx = subpath.indexOf('/');
+        const segment =
+            segmentIdx === -1 ? subpath : subpath.slice(0, segmentIdx);
+        if (segment === '..') {
+            throw 'no-entry';
+        }
+        if (segment === '.' || segment === '') {
+        } else if (!entry.dir[segment] && openFlags.create) {
+            entry = entry.dir[segment] = openFlags.directory
+                ? { dir: {} }
+                : { source: new Uint8Array([]) };
+        } else {
+            entry = entry.dir[segment];
+        }
+        subpath = subpath.slice(segmentIdx + 1);
+    } while (segmentIdx !== -1);
+    if (!entry) {
+        throw 'no-entry';
+    }
+    return entry;
+}
+
+function getSource(fileEntry) {
+    if (typeof fileEntry.source === 'string') {
+        fileEntry.source = new TextEncoder().encode(fileEntry.source);
+    }
+    return fileEntry.source;
+}
+
+class DirectoryEntryStream {
+    constructor(entries) {
+        this.idx = 0;
+        this.entries = entries;
+    }
+    readDirectoryEntry() {
+        if (this.idx === this.entries.length) {
+            return null;
+        }
+        const [name, entry] = this.entries[this.idx];
+        this.idx += 1;
+        return {
+            name,
+            type: entry.dir ? 'directory' : 'regular-file',
+        };
+    }
+}
+
+class Descriptor {
+    #stream;
+    #entry;
+    #mtime = 0;
+
+    _getEntry(descriptor) {
+        return descriptor.#entry;
+    }
+
+    constructor(entry, isStream) {
+        if (isStream) {
+            this.#stream = entry;
+        } else {
+            this.#entry = entry;
+        }
+    }
+
+    readViaStream(_offset) {
+        const source = getSource(this.#entry);
+        let offset = Number(_offset);
+        return new InputStream({
+            blockingRead(len) {
+                if (offset === source.byteLength) {
+                    throw { tag: 'closed' };
+                }
+                const bytes = source.slice(offset, offset + Number(len));
+                offset += bytes.byteLength;
+                return bytes;
+            },
+        });
+    }
+
+    writeViaStream(_offset) {
+        const entry = this.#entry;
+        let offset = Number(_offset);
+        return new OutputStream({
+            write(buf) {
+                const newSource = new Uint8Array(
+                    buf.byteLength + entry.source.byteLength
+                );
+                newSource.set(entry.source, 0);
+                newSource.set(buf, offset);
+                offset += buf.byteLength;
+                entry.source = newSource;
+                return buf.byteLength;
+            },
+        });
+    }
+
+    appendViaStream() {
+        console.log(`[filesystem] APPEND STREAM`);
+    }
+
+    advise(descriptor, offset, length, advice) {
+        console.log(`[filesystem] ADVISE`, descriptor, offset, length, advice);
+    }
+
+    syncData() {
+        console.log(`[filesystem] SYNC DATA`);
+    }
+
+    getFlags() {
+        console.log(`[filesystem] FLAGS FOR`);
+    }
+
+    getType() {
+        if (this.#stream) {
+            return 'fifo';
+        }
+        if (this.#entry.dir) {
+            return 'directory';
+        }
+        if (this.#entry.source) {
+            return 'regular-file';
+        }
+        return 'unknown';
+    }
+
+    setSize(size) {
+        console.log(`[filesystem] SET SIZE`, size);
+    }
+
+    setTimes(dataAccessTimestamp, dataModificationTimestamp) {
+        console.log(
+            `[filesystem] SET TIMES`,
+            dataAccessTimestamp,
+            dataModificationTimestamp
+        );
+    }
+
+    read(length, offset) {
+        const source = getSource(this.#entry);
+        return [
+            source.slice(offset, offset + length),
+            offset + length >= source.byteLength,
+        ];
+    }
+
+    write(buffer, offset) {
+        if (offset !== 0) {
+            throw 'invalid-seek';
+        }
+        this.#entry.source = buffer;
+        return buffer.byteLength;
+    }
+
+    readDirectory() {
+        if (!this.#entry?.dir) {
+            throw 'bad-descriptor';
+        }
+        return new DirectoryEntryStream(
+            Object.entries(this.#entry.dir).sort(([a], [b]) => (a > b ? 1 : -1))
+        );
+    }
+
+    sync() {
+        console.log(`[filesystem] SYNC`);
+    }
+
+    createDirectoryAt(path) {
+        const entry = getChildEntry(this.#entry, path, {
+            create: true,
+            directory: true,
+        });
+        if (entry.source) {
+            throw 'exist';
+        }
+    }
+
+    stat() {
+        let type = 'unknown',
+            size = BigInt(0);
+        if (this.#entry.source) {
+            type = 'regular-file';
+            const source = getSource(this.#entry);
+            size = BigInt(source.byteLength);
+        } else if (this.#entry.dir) {
+            type = 'directory';
+        }
+        return {
+            type,
+            linkCount: BigInt(0),
+            size,
+            dataAccessTimestamp: timeZero,
+            dataModificationTimestamp: timeZero,
+            statusChangeTimestamp: timeZero,
+        };
+    }
+
+    statAt(_pathFlags, path) {
+        const entry = getChildEntry(this.#entry, path, {
+            create: false,
+            directory: false,
+        });
+        let type = 'unknown',
+            size = BigInt(0);
+        if (entry.source) {
+            type = 'regular-file';
+            const source = getSource(entry);
+            size = BigInt(source.byteLength);
+        } else if (entry.dir) {
+            type = 'directory';
+        }
+        return {
+            type,
+            linkCount: BigInt(0),
+            size,
+            dataAccessTimestamp: timeZero,
+            dataModificationTimestamp: timeZero,
+            statusChangeTimestamp: timeZero,
+        };
+    }
+
+    setTimesAt() {
+        console.log(`[filesystem] SET TIMES AT`);
+    }
+
+    linkAt() {
+        console.log(`[filesystem] LINK AT`);
+    }
+
+    openAt(_pathFlags, path, openFlags, _descriptorFlags, _modes) {
+        const childEntry = getChildEntry(this.#entry, path, openFlags);
+        return new Descriptor(childEntry);
+    }
+
+    readlinkAt() {
+        console.log(`[filesystem] READLINK AT`);
+    }
+
+    removeDirectoryAt() {
+        console.log(`[filesystem] REMOVE DIR AT`);
+    }
+
+    renameAt() {
+        console.log(`[filesystem] RENAME AT`);
+    }
+
+    symlinkAt() {
+        console.log(`[filesystem] SYMLINK AT`);
+    }
+
+    unlinkFileAt() {
+        console.log(`[filesystem] UNLINK FILE AT`);
+    }
+
+    isSameObject(other) {
+        return other === this;
+    }
+
+    metadataHash() {
+        let upper = BigInt(0);
+        upper += BigInt(this.#mtime);
+        return { upper, lower: BigInt(0) };
+    }
+
+    metadataHashAt(_pathFlags, _path) {
+        let upper = BigInt(0);
+        upper += BigInt(this.#mtime);
+        return { upper, lower: BigInt(0) };
+    }
+}
+const descriptorGetEntry = Descriptor.prototype._getEntry;
+delete Descriptor.prototype._getEntry;
+
+let _preopens = [[new Descriptor(_fileData), '/']],
+    _rootPreopen = _preopens[0];
+
+export const preopens = {
+    getDirectories() {
+        return _preopens;
+    },
+};
+
+export const types = {
+    Descriptor,
+    DirectoryEntryStream,
+};
+
+export { types as filesystemTypes };

--- a/packages/preview2-shim/lib/iwa/http.js
+++ b/packages/preview2-shim/lib/iwa/http.js
@@ -1,0 +1,145 @@
+/**
+ * @param {import("../../types/interfaces/wasi-http-types").Request} req
+ * @returns {string}
+ */
+export function send(req) {
+    console.log(`[http] Send (browser) ${req.uri}`);
+    try {
+        const xhr = new XMLHttpRequest();
+        xhr.open(req.method.toString(), req.uri, false);
+        const requestHeaders = new Headers(req.headers);
+        for (let [name, value] of requestHeaders.entries()) {
+            if (name !== 'user-agent' && name !== 'host') {
+                xhr.setRequestHeader(name, value);
+            }
+        }
+        xhr.send(req.body && req.body.length > 0 ? req.body : null);
+        const body = xhr.response
+            ? new TextEncoder().encode(xhr.response)
+            : undefined;
+        const headers = [];
+        xhr.getAllResponseHeaders()
+            .trim()
+            .split(/[\r\n]+/)
+            .forEach((line) => {
+                var parts = line.split(': ');
+                var key = parts.shift();
+                var value = parts.join(': ');
+                headers.push([key, value]);
+            });
+        return {
+            status: xhr.status,
+            headers,
+            body,
+        };
+    } catch (err) {
+        throw new Error(err.message);
+    }
+}
+
+export const incomingHandler = {
+    handle() {},
+};
+
+export const outgoingHandler = {
+    handle() {},
+};
+
+export const types = {
+    dropFields(_fields) {
+        console.log('[types] Drop fields');
+    },
+    newFields(_entries) {
+        console.log('[types] New fields');
+    },
+    fieldsGet(_fields, _name) {
+        console.log('[types] Fields get');
+    },
+    fieldsSet(_fields, _name, _value) {
+        console.log('[types] Fields set');
+    },
+    fieldsDelete(_fields, _name) {
+        console.log('[types] Fields delete');
+    },
+    fieldsAppend(_fields, _name, _value) {
+        console.log('[types] Fields append');
+    },
+    fieldsEntries(_fields) {
+        console.log('[types] Fields entries');
+    },
+    fieldsClone(_fields) {
+        console.log('[types] Fields clone');
+    },
+    finishIncomingStream(s) {
+        console.log(`[types] Finish incoming stream ${s}`);
+    },
+    finishOutgoingStream(s, _trailers) {
+        console.log(`[types] Finish outgoing stream ${s}`);
+    },
+    dropIncomingRequest(_req) {
+        console.log('[types] Drop incoming request');
+    },
+    dropOutgoingRequest(_req) {
+        console.log('[types] Drop outgoing request');
+    },
+    incomingRequestMethod(_req) {
+        console.log('[types] Incoming request method');
+    },
+    incomingRequestPathWithQuery(_req) {
+        console.log('[types] Incoming request path with query');
+    },
+    incomingRequestScheme(_req) {
+        console.log('[types] Incoming request scheme');
+    },
+    incomingRequestAuthority(_req) {
+        console.log('[types] Incoming request authority');
+    },
+    incomingRequestHeaders(_req) {
+        console.log('[types] Incoming request headers');
+    },
+    incomingRequestConsume(_req) {
+        console.log('[types] Incoming request consume');
+    },
+    newOutgoingRequest(_method, _pathWithQuery, _scheme, _authority, _headers) {
+        console.log('[types] New outgoing request');
+    },
+    outgoingRequestWrite(_req) {
+        console.log('[types] Outgoing request write');
+    },
+    dropResponseOutparam(_res) {
+        console.log('[types] Drop response outparam');
+    },
+    setResponseOutparam(_response) {
+        console.log('[types] Drop fields');
+    },
+    dropIncomingResponse(_res) {
+        console.log('[types] Drop incoming response');
+    },
+    dropOutgoingResponse(_res) {
+        console.log('[types] Drop outgoing response');
+    },
+    incomingResponseStatus(_res) {
+        console.log('[types] Incoming response status');
+    },
+    incomingResponseHeaders(_res) {
+        console.log('[types] Incoming response headers');
+    },
+    incomingResponseConsume(_res) {
+        console.log('[types] Incoming response consume');
+    },
+    newOutgoingResponse(_statusCode, _headers) {
+        console.log('[types] New outgoing response');
+    },
+    outgoingResponseWrite(_res) {
+        console.log('[types] Outgoing response write');
+    },
+    dropFutureIncomingResponse(_f) {
+        console.log('[types] Drop future incoming response');
+    },
+    futureIncomingResponseGet(_f) {
+        console.log('[types] Future incoming response get');
+    },
+    listenToFutureIncomingResponse(_f) {
+        console.log('[types] Listen to future incoming response');
+    },
+};

--- a/packages/preview2-shim/lib/iwa/index.js
+++ b/packages/preview2-shim/lib/iwa/index.js
@@ -1,0 +1,9 @@
+import * as clocks from './clocks.js';
+import * as filesystem from './filesystem.js';
+import * as http from './http.js';
+import * as io from './io.js';
+import * as random from './random.js';
+import * as sockets from './sockets.js';
+import * as cli from './cli.js';
+
+export { clocks, filesystem, http, io, random, sockets, cli };

--- a/packages/preview2-shim/lib/iwa/io.js
+++ b/packages/preview2-shim/lib/iwa/io.js
@@ -1,0 +1,193 @@
+let id = 0;
+
+const symbolDispose = Symbol.dispose || Symbol.for('dispose');
+
+const IoError = class Error {
+    constructor(msg) {
+        this.msg = msg;
+    }
+    toDebugString() {
+        return this.msg;
+    }
+};
+
+/**
+ * @typedef {{
+ *   read?: (len: BigInt) => Uint8Array,
+ *   blockingRead: (len: BigInt) => Uint8Array,
+ *   skip?: (len: BigInt) => BigInt,
+ *   blockingSkip?: (len: BigInt) => BigInt,
+ *   subscribe: () => void,
+ *   drop?: () => void,
+ * }} InputStreamHandler
+ *
+ * @typedef {{
+ *   checkWrite?: () -> BigInt,
+ *   write: (buf: Uint8Array) => BigInt,
+ *   blockingWriteAndFlush?: (buf: Uint8Array) => void,
+ *   flush?: () => void,
+ *   blockingFlush: () => void,
+ *   writeZeroes?: (len: BigInt) => void,
+ *   blockingWriteZeroes?: (len: BigInt) => void,
+ *   blockingWriteZeroesAndFlush?: (len: BigInt) => void,
+ *   splice?: (src: InputStream, len: BigInt) => BigInt,
+ *   blockingSplice?: (src: InputStream, len: BigInt) => BigInt,
+ *   forward?: (src: InputStream) => void,
+ *   subscribe?: () => void,
+ *   drop?: () => void,
+ * }} OutputStreamHandler
+ *
+ **/
+
+class InputStream {
+    /**
+     * @param {InputStreamHandler} handler
+     */
+    constructor(handler) {
+        if (!handler) {
+            console.trace('no handler');
+        }
+        this.id = ++id;
+        this.handler = handler;
+    }
+    read(len) {
+        if (this.handler.read) {
+            return this.handler.read(len);
+        }
+        return this.handler.blockingRead.call(this, len);
+    }
+    blockingRead(len) {
+        return this.handler.blockingRead.call(this, len);
+    }
+    skip(len) {
+        if (this.handler.skip) {
+            return this.handler.skip.call(this, len);
+        }
+        if (this.handler.read) {
+            const bytes = this.handler.read.call(this, len);
+            return BigInt(bytes.byteLength);
+        }
+        return this.blockingSkip.call(this, len);
+    }
+    blockingSkip(len) {
+        if (this.handler.blockingSkip) {
+            return this.handler.blockingSkip.call(this, len);
+        }
+        const bytes = this.handler.blockingRead.call(this, len);
+        return BigInt(bytes.byteLength);
+    }
+    subscribe() {
+        console.log(`[streams] Subscribe to input stream ${this.id}`);
+    }
+    [symbolDispose]() {
+        if (this.handler.drop) {
+            this.handler.drop.call(this);
+        }
+    }
+}
+
+class OutputStream {
+    /**
+     * @param {OutputStreamHandler} handler
+     */
+    constructor(handler) {
+        if (!handler) {
+            console.trace('no handler');
+        }
+        this.id = ++id;
+        this.open = true;
+        this.handler = handler;
+    }
+    checkWrite(len) {
+        if (!this.open) {
+            return 0n;
+        }
+        if (this.handler.checkWrite) {
+            return this.handler.checkWrite.call(this, len);
+        }
+        return 1_000_000n;
+    }
+    write(buf) {
+        this.handler.write.call(this, buf);
+    }
+    blockingWriteAndFlush(buf) {
+        /// Perform a write of up to 4096 bytes, and then flush the stream. Block
+        /// until all of these operations are complete, or an error occurs.
+        ///
+        /// This is a convenience wrapper around the use of `check-write`,
+        /// `subscribe`, `write`, and `flush`, and is implemented with the
+        /// following pseudo-code:
+        ///
+        /// ```text
+        /// let pollable = this.subscribe();
+        /// while !contents.is_empty() {
+        ///     // Wait for the stream to become writable
+        ///     poll-one(pollable);
+        ///     let Ok(n) = this.check-write(); // eliding error handling
+        ///     let len = min(n, contents.len());
+        ///     let (chunk, rest) = contents.split_at(len);
+        ///     this.write(chunk  );            // eliding error handling
+        ///     contents = rest;
+        /// }
+        /// this.flush();
+        /// // Wait for completion of `flush`
+        /// poll-one(pollable);
+        /// // Check for any errors that arose during `flush`
+        /// let _ = this.check-write();         // eliding error handling
+        /// ```
+        this.handler.write.call(this, buf);
+    }
+    flush() {
+        if (this.handler.flush) {
+            this.handler.flush.call(this);
+        }
+    }
+    blockingFlush() {
+        this.open = true;
+    }
+    writeZeroes(len) {
+        this.write.call(this, new Uint8Array(Number(len)));
+    }
+    blockingWriteZeroes(len) {
+        this.blockingWrite.call(this, new Uint8Array(Number(len)));
+    }
+    blockingWriteZeroesAndFlush(len) {
+        this.blockingWriteAndFlush.call(this, new Uint8Array(Number(len)));
+    }
+    splice(src, len) {
+        const spliceLen = Math.min(len, this.checkWrite.call(this));
+        const bytes = src.read(spliceLen);
+        this.write.call(this, bytes);
+        return bytes.byteLength;
+    }
+    blockingSplice(_src, _len) {
+        console.log(`[streams] Blocking splice ${this.id}`);
+    }
+    forward(_src) {
+        console.log(`[streams] Forward ${this.id}`);
+    }
+    subscribe() {
+        console.log(`[streams] Subscribe to output stream ${this.id}`);
+    }
+    [symbolDispose]() {}
+}
+
+export const error = { Error: IoError };
+
+export const streams = { InputStream, OutputStream };
+
+class Pollable {}
+
+function pollList(_list) {
+    // TODO
+}
+
+function pollOne(_poll) {
+    // TODO
+}
+
+export const poll = {
+    Pollable,
+    pollList,
+    pollOne,
+};

--- a/packages/preview2-shim/lib/iwa/random.js
+++ b/packages/preview2-shim/lib/iwa/random.js
@@ -1,0 +1,58 @@
+const MAX_BYTES = 65536;
+
+let insecureRandomValue1, insecureRandomValue2;
+
+export const insecure = {
+    getInsecureRandomBytes(len) {
+        return random.getRandomBytes(len);
+    },
+    getInsecureRandomU64() {
+        return random.getRandomU64();
+    },
+};
+
+let insecureSeedValue1, insecureSeedValue2;
+
+export const insecureSeed = {
+    insecureSeed() {
+        if (insecureSeedValue1 === undefined) {
+            insecureSeedValue1 = random.getRandomU64();
+            insecureSeedValue2 = random.getRandomU64();
+        }
+        return [insecureSeedValue1, insecureSeedValue2];
+    },
+};
+
+export const random = {
+    getRandomBytes(len) {
+        const bytes = new Uint8Array(Number(len));
+
+        if (len > MAX_BYTES) {
+            // this is the max bytes crypto.getRandomValues
+            // can do at once see https://developer.mozilla.org/en-US/docs/Web/API/window.crypto.getRandomValues
+            for (var generated = 0; generated < len; generated += MAX_BYTES) {
+                // buffer.slice automatically checks if the end is past the end of
+                // the buffer so we don't have to here
+                crypto.getRandomValues(
+                    bytes.subarray(generated, generated + MAX_BYTES)
+                );
+            }
+        } else {
+            crypto.getRandomValues(bytes);
+        }
+
+        return bytes;
+    },
+
+    getRandomU64() {
+        return crypto.getRandomValues(new BigUint64Array(1))[0];
+    },
+
+    insecureRandom() {
+        if (insecureRandomValue1 === undefined) {
+            insecureRandomValue1 = random.getRandomU64();
+            insecureRandomValue2 = random.getRandomU64();
+        }
+        return [insecureRandomValue1, insecureRandomValue2];
+    },
+};

--- a/packages/preview2-shim/lib/iwa/sockets.js
+++ b/packages/preview2-shim/lib/iwa/sockets.js
@@ -1,0 +1,151 @@
+export const instanceNetwork = {
+    instanceNetwork() {
+        console.log(`[sockets] instance network`);
+    },
+};
+
+export const ipNameLookup = {
+    dropResolveAddressStream() {},
+    subscribe() {},
+    resolveAddresses() {},
+    resolveNextAddress() {},
+    nonBlocking() {},
+    setNonBlocking() {},
+};
+
+export const network = {
+    dropNetwork() {},
+};
+
+// TCP implementation using the Direct Sockets API
+export const tcpCreateSocket = {
+    /**
+     * Create a new TCP socket connected to the given address and port.
+     * @param {string} remoteAddress
+     * @param {number} remotePort
+     * @param {TCPSocketOptions} [options]
+     * @returns {TCPSocket}
+     */
+    createTcpSocket(remoteAddress, remotePort, options = {}) {
+        return new TCPSocket(remoteAddress, remotePort, options);
+    },
+};
+
+export const tcp = {
+    /**
+     * Wait until the socket connection is established.
+     * @param {TCPSocket} socket
+     */
+    async connect(socket) {
+        await socket.opened;
+    },
+    /**
+     * Send data on the TCP socket.
+     * @param {TCPSocket} socket
+     * @param {Uint8Array} data
+     */
+    async send(socket, data) {
+        const { writable } = await socket.opened;
+        const writer = writable.getWriter();
+        await writer.write(data);
+        writer.releaseLock();
+    },
+    /**
+     * Receive data from the TCP socket.
+     * @param {TCPSocket} socket
+     * @returns {Promise<Uint8Array | undefined>}
+     */
+    async receive(socket) {
+        const { readable } = await socket.opened;
+        const reader = readable.getReader();
+        const { value } = await reader.read();
+        reader.releaseLock();
+        return value;
+    },
+    /**
+     * Close the TCP socket.
+     * @param {TCPSocket} socket
+     */
+    shutdown(socket) {
+        socket.close();
+    },
+    dropTcpSocket(socket) {
+        socket.close();
+    },
+    // The Direct Sockets API does not currently expose these features.
+    subscribe() { throw new Error('not supported'); },
+    bind() { throw new Error('not supported'); },
+    listen() { throw new Error('not supported'); },
+    accept() { throw new Error('not supported'); },
+    localAddress() { throw new Error('not supported'); },
+    remoteAddress() { throw new Error('not supported'); },
+    addressFamily() { throw new Error('not supported'); },
+    setListenBacklogSize() { throw new Error('not supported'); },
+    keepAlive() { throw new Error('not supported'); },
+    setKeepAlive() { throw new Error('not supported'); },
+    noDelay() { throw new Error('not supported'); },
+    setNoDelay() { throw new Error('not supported'); },
+    unicastHopLimit() { throw new Error('not supported'); },
+    setUnicastHopLimit() { throw new Error('not supported'); },
+    receiveBufferSize() { throw new Error('not supported'); },
+    setReceiveBufferSize() { throw new Error('not supported'); },
+    sendBufferSize() { throw new Error('not supported'); },
+    setSendBufferSize() { throw new Error('not supported'); },
+    nonBlocking() { throw new Error('not supported'); },
+    setNonBlocking() { throw new Error('not supported'); },
+};
+
+// UDP implementation using the Direct Sockets API
+export const udpCreateSocket = {
+    /**
+     * Create a new UDP socket.
+     * @param {UDPSocketOptions} [options]
+     * @returns {UDPSocket}
+     */
+    createUdpSocket(options = {}) {
+        return new UDPSocket(options);
+    },
+};
+
+export const udp = {
+    /**
+     * Send data on the UDP socket.
+     * @param {UDPSocket} socket
+     * @param {Uint8Array} data
+     */
+    async send(socket, data) {
+        const { writable } = await socket.opened;
+        const writer = writable.getWriter();
+        await writer.write(data);
+        writer.releaseLock();
+    },
+    /**
+     * Receive data from the UDP socket.
+     * @param {UDPSocket} socket
+     * @returns {Promise<Uint8Array | undefined>}
+     */
+    async receive(socket) {
+        const { readable } = await socket.opened;
+        const reader = readable.getReader();
+        const { value } = await reader.read();
+        reader.releaseLock();
+        return value;
+    },
+    dropUdpSocket(socket) {
+        socket.close();
+    },
+    subscribe() { throw new Error('not supported'); },
+    bind() { throw new Error('not supported'); },
+    connect() { throw new Error('not supported'); },
+    localAddress() { throw new Error('not supported'); },
+    remoteAddress() { throw new Error('not supported'); },
+    addressFamily() { throw new Error('not supported'); },
+    unicastHopLimit() { throw new Error('not supported'); },
+    setUnicastHopLimit() { throw new Error('not supported'); },
+    receiveBufferSize() { throw new Error('not supported'); },
+    setReceiveBufferSize() { throw new Error('not supported'); },
+    sendBufferSize() { throw new Error('not supported'); },
+    setSendBufferSize() { throw new Error('not supported'); },
+    nonBlocking() { throw new Error('not supported'); },
+    setNonBlocking() { throw new Error('not supported'); },
+};


### PR DESCRIPTION
## Summary
- copy browser shim to new `iwa` target
- add TCP/UDP support using the Direct Sockets API

## Testing
- `npm test` (fails: connect ENETUNREACH)
- `npm run lint`

